### PR TITLE
ext. visibility time out + comment out receive msg

### DIFF
--- a/create_task/serverless.yml
+++ b/create_task/serverless.yml
@@ -15,7 +15,7 @@ custom:
   dotenv:
     path: ../.env
   pythonRequirements:
-    dockerizePip: false
+    dockerizePip: non-linux
 
 provider:
   name: aws

--- a/create_task/sqsutil.py
+++ b/create_task/sqsutil.py
@@ -65,7 +65,6 @@ def receive_message(queue_url):
         MessageAttributeNames=[
             'All'
         ],
-        VisibilityTimeout=0,
         WaitTimeSeconds=0
     )
     message = None

--- a/create_task/taskmessage.py
+++ b/create_task/taskmessage.py
@@ -66,14 +66,14 @@ def send_task_message(queue_name, action, task):
     print('MessageId: %s' % message_id)
     print('MessageBodyJSON: %s' % message_body_json)
 
-    # debug: receive message
-    message = sqsutil.receive_message(queue_url)
-    if message is None:
-        print('send_task_message: cannot retrieve sent message.')
-        print('(When downstream Lambda function is running, missing message is expected.)')
-    else:
-        print('Received message:')
-        print(message)
+    # # debug: receive message
+    # message = sqsutil.receive_message(queue_url)
+    # if message is None:
+    #     print('send_task_message: cannot retrieve sent message.')
+    #     print('(When downstream Lambda function is running, missing message is expected.)')
+    # else:
+    #     print('Received message:')
+    #     print(message)
 
     # success
     return True

--- a/process_task/sqsutil.py
+++ b/process_task/sqsutil.py
@@ -65,7 +65,6 @@ def receive_message(queue_url):
         MessageAttributeNames=[
             'All'
         ],
-        VisibilityTimeout=0,
         WaitTimeSeconds=0
     )
     message = None

--- a/process_task/taskmessage.py
+++ b/process_task/taskmessage.py
@@ -66,14 +66,14 @@ def send_task_message(queue_name, action, task):
     print('MessageId: %s' % message_id)
     print('MessageBodyJSON: %s' % message_body_json)
 
-    # debug: receive message
-    message = sqsutil.receive_message(queue_url)
-    if message is None:
-        print('send_task_message: cannot retrieve sent message.')
-        print('(When downstream Lambda function is running, missing message is expected.)')
-    else:
-        print('Received message:')
-        print(message)
+    # # debug: receive message
+    # message = sqsutil.receive_message(queue_url)
+    # if message is None:
+    #     print('send_task_message: cannot retrieve sent message.')
+    #     print('(When downstream Lambda function is running, missing message is expected.)')
+    # else:
+    #     print('Received message:')
+    #     print(message)
 
     # success
     return True

--- a/resources/task-exec-queues.yml
+++ b/resources/task-exec-queues.yml
@@ -11,6 +11,7 @@ Resources:
     Type: "AWS::SQS::Queue"
     Properties:
       QueueName: "${self:custom.processTaskQueue}"
+      VisibilityTimeout: 9000
   UpdateTaskQueue:
     Type: "AWS::SQS::Queue"
     Properties:

--- a/submit_task/sqsutil.py
+++ b/submit_task/sqsutil.py
@@ -65,7 +65,6 @@ def receive_message(queue_url):
         MessageAttributeNames=[
             'All'
         ],
-        VisibilityTimeout=0,
         WaitTimeSeconds=0
     )
     message = None

--- a/submit_task/taskmessage.py
+++ b/submit_task/taskmessage.py
@@ -66,14 +66,14 @@ def send_task_message(queue_name, action, task):
     print('MessageId: %s' % message_id)
     print('MessageBodyJSON: %s' % message_body_json)
 
-    # debug: receive message
-    message = sqsutil.receive_message(queue_url)
-    if message is None:
-        print('send_task_message: cannot retrieve sent message.')
-        print('(When downstream Lambda function is running, missing message is expected.)')
-    else:
-        print('Received message:')
-        print(message)
+    # # debug: receive message
+    # message = sqsutil.receive_message(queue_url)
+    # if message is None:
+    #     print('send_task_message: cannot retrieve sent message.')
+    #     print('(When downstream Lambda function is running, missing message is expected.)')
+    # else:
+    #     print('Received message:')
+    #     print(message)
 
     # success
     return True

--- a/update_task/sqsutil.py
+++ b/update_task/sqsutil.py
@@ -65,7 +65,6 @@ def receive_message(queue_url):
         MessageAttributeNames=[
             'All'
         ],
-        VisibilityTimeout=0,
         WaitTimeSeconds=0
     )
     message = None

--- a/update_task/taskmessage.py
+++ b/update_task/taskmessage.py
@@ -66,14 +66,14 @@ def send_task_message(queue_name, action, task):
     print('MessageId: %s' % message_id)
     print('MessageBodyJSON: %s' % message_body_json)
 
-    # debug: receive message
-    message = sqsutil.receive_message(queue_url)
-    if message is None:
-        print('send_task_message: cannot retrieve sent message.')
-        print('(When downstream Lambda function is running, missing message is expected.)')
-    else:
-        print('Received message:')
-        print(message)
+    # # debug: receive message
+    # message = sqsutil.receive_message(queue_url)
+    # if message is None:
+    #     print('send_task_message: cannot retrieve sent message.')
+    #     print('(When downstream Lambda function is running, missing message is expected.)')
+    # else:
+    #     print('Received message:')
+    #     print(message)
 
     # success
     return True

--- a/upload_task_issues/sqsutil.py
+++ b/upload_task_issues/sqsutil.py
@@ -65,7 +65,6 @@ def receive_message(queue_url):
         MessageAttributeNames=[
             'All'
         ],
-        VisibilityTimeout=0,
         WaitTimeSeconds=0
     )
     message = None

--- a/upload_task_issues/taskmessage.py
+++ b/upload_task_issues/taskmessage.py
@@ -66,14 +66,14 @@ def send_task_message(queue_name, action, task):
     print('MessageId: %s' % message_id)
     print('MessageBodyJSON: %s' % message_body_json)
 
-    # debug: receive message
-    message = sqsutil.receive_message(queue_url)
-    if message is None:
-        print('send_task_message: cannot retrieve sent message.')
-        print('(When downstream Lambda function is running, missing message is expected.)')
-    else:
-        print('Received message:')
-        print(message)
+    # # debug: receive message
+    # message = sqsutil.receive_message(queue_url)
+    # if message is None:
+    #     print('send_task_message: cannot retrieve sent message.')
+    #     print('(When downstream Lambda function is running, missing message is expected.)')
+    # else:
+    #     print('Received message:')
+    #     print(message)
 
     # success
     return True


### PR DESCRIPTION
extend visibility time out of process task queue to 9000 seconds (150 minutes)
as a result: need to commend out the debugging receive message call

also: roll back dockerizePip to "non-linux".
Note: if we run into file permission issue, can try to change dockerizePip to "false".